### PR TITLE
Reformat profile creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ littleblog/avatars/
 *.pot
 *.pyc
 __pycache__/
+*/*/*/__pycache__/
+*/*/__pycache__/
+*/__pycache__/
 local_settings.py
 db.sqlite3
 media

--- a/littleblog/entry/models.py
+++ b/littleblog/entry/models.py
@@ -10,6 +10,8 @@ class UserProfile(models.Model):
     nickname = models.CharField(max_length=255)
     avatar = models.ImageField(upload_to='avatars', blank=True)
 
+    objects = models.Manager
+
     def __str__(self):
         return self.nickname
 

--- a/littleblog/entry/permissons.py
+++ b/littleblog/entry/permissons.py
@@ -17,7 +17,4 @@ class IsAuthenticatedOrWriteOnly(permissions.BasePermission):
     def has_permission(self, request, view):
         write_methods = ["POST", ]
 
-        return (
-            request.method in write_methods or
-            isinstance(request.user, AnonymousUser)
-        )
+        return request.method in write_methods or request.user.is_authenticated

--- a/littleblog/entry/permissons.py
+++ b/littleblog/entry/permissons.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
+from django.contrib.auth.models import AnonymousUser
 
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
@@ -6,3 +7,17 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return True
         return obj.author.user == request.user
+
+
+class IsAuthenticatedOrWriteOnly(permissions.BasePermission):
+    """
+    The request is authenticated as a user, or is a write-only request.
+    """
+
+    def has_permission(self, request, view):
+        write_methods = ["POST", ]
+
+        return (
+            request.method in write_methods or
+            isinstance(request.user, AnonymousUser)
+        )

--- a/littleblog/entry/serializers.py
+++ b/littleblog/entry/serializers.py
@@ -8,7 +8,7 @@ from django.contrib.auth.password_validation import UserAttributeSimilarityValid
 
 class UserProfileCreateSerializer(serializers.ModelSerializer):
 
-    UserProfile = serializers.ReadOnlyField(source='profile.nickname')
+    profile = serializers.ReadOnlyField(source='profile.nickname')
     nickname = serializers.CharField(source="profile.name")
     avatar = serializers.ImageField(source="profile.avatar", required=False)
 

--- a/littleblog/entry/serializers.py
+++ b/littleblog/entry/serializers.py
@@ -21,9 +21,9 @@ class UserProfileCreateSerializer(serializers.ModelSerializer):
             'nickname': {'validators': [UniqueValidator(queryset=User.objects.all())]}
         }
 
-    def validate_password(self, value):
-        validate_password(value)
-        return value
+    def validate(self, attrs):
+        validate_password(attrs["password"], user=User(username=attrs["username"]))
+        return attrs
 
     def create(self, validated_data):
         credentials = {'username': validated_data.pop('username'), 'password': validated_data.pop('password')}

--- a/littleblog/entry/serializers.py
+++ b/littleblog/entry/serializers.py
@@ -28,8 +28,7 @@ class UserProfileCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         credentials = {'username': validated_data.pop('username'), 'password': validated_data.pop('password')}
         user = User.objects.create_user(**credentials)
-        user_profile_data = {'user': user, **validated_data}
-        UserProfile.objects.create(**user_profile_data)
+        UserProfile.objects.create(user=user, **validated_data}
         return user
 
 

--- a/littleblog/entry/serializers.py
+++ b/littleblog/entry/serializers.py
@@ -9,8 +9,8 @@ from django.contrib.auth.password_validation import UserAttributeSimilarityValid
 class UserProfileCreateSerializer(serializers.ModelSerializer):
 
     UserProfile = serializers.ReadOnlyField(source='profile.nickname')
-    nickname = serializers.CharField(max_length=50, required=True, write_only=True)
-    avatar = serializers.ImageField(required=False, write_only=True)
+    nickname = serializers.CharField(source="profile.name")
+    avatar = serializers.ImageField(source="profile.avatar", required=False)
 
     class Meta:
         model = User

--- a/littleblog/entry/urls.py
+++ b/littleblog/entry/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import UserProfileCreateRetrieveView, EntryViewSet, RateUpdateView
+from .views import UserProfileListCreateView, EntryViewSet, RateUpdateView
 from rest_framework.routers import DefaultRouter
 
 app_name = 'entry'
@@ -8,8 +8,7 @@ router = DefaultRouter()
 router.register('entries', EntryViewSet)
 
 urlpatterns = [
-    path('profile/', UserProfileCreateRetrieveView.as_view()),
-    path('profile/<int:pk>/', UserProfileCreateRetrieveView.as_view()),
+    path('profiles/', UserProfileListCreateView.as_view()),
     path('rate_entry/', RateUpdateView.as_view())
 ]
 

--- a/littleblog/entry/urls.py
+++ b/littleblog/entry/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import UserProfileCreateView, EntryViewSet, RateUpdateView
+from .views import UserProfileCreateRetrieveView, EntryViewSet, RateUpdateView
 from rest_framework.routers import DefaultRouter
 
 app_name = 'entry'
@@ -8,7 +8,8 @@ router = DefaultRouter()
 router.register('entries', EntryViewSet)
 
 urlpatterns = [
-    path('create_profile/', UserProfileCreateView.as_view()),
+    path('profile/', UserProfileCreateRetrieveView.as_view()),
+    path('profile/<int:pk>/', UserProfileCreateRetrieveView.as_view()),
     path('rate_entry/', RateUpdateView.as_view())
 ]
 

--- a/littleblog/entry/views.py
+++ b/littleblog/entry/views.py
@@ -9,39 +9,11 @@ from django.contrib.auth import get_user_model
 from rest_framework import status
 
 
-class UserProfileCreateRetrieveView(generics.RetrieveAPIView,
-                                    generics.CreateAPIView):
+class UserProfileListCreateView(generics.ListCreateAPIView):
 
     serializer_class = UserProfileCreateSerializer
     queryset = get_user_model().objects.all()
     permission_classes = (IsAuthenticatedOrWriteOnly,)
-
-
-# class UserProfileCreateView(generics.CreateAPIView):
-#
-#     serializer_class = UserProfileCreateSerializer
-#
-#     def create(self, request, *args, **kwargs):
-#         data = request.data.dict()
-#         data.pop('username')
-#         data.pop('password')
-#         data['user'] = kwargs.pop('user')
-#         serializer = self.get_serializer(data=data)
-#         serializer.is_valid(raise_exception=True)
-#         self.perform_create(serializer)
-#         headers = self.get_success_headers(serializer.data)
-#         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
-#
-#     def post(self, request, *args, **kwargs):
-#         """
-#         Сделаем так, чтобы User и UserProfile создавались одним махом. УРА! В этом коммите я сделал это! Для минимального
-#         POST запроса нужны :  username и password (для создания модельки User), и nickname для модельки UserProfile.
-#         """
-#         usermodel = get_user_model()
-#         user = usermodel.objects.create_user(username=request.data['username'], password=request.data['password'])
-#         kwargs['user'] = user.pk
-#
-#         return self.create(request, *args, **kwargs)
 
 
 class EntryViewSet(viewsets.ModelViewSet):

--- a/littleblog/entry/views.py
+++ b/littleblog/entry/views.py
@@ -39,18 +39,12 @@ class UserProfileCreateView(generics.CreateAPIView):
 class EntryViewSet(viewsets.ModelViewSet):
 
     queryset = Entry.objects.all()
+    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
 
     def get_serializer_class(self):
         if self.action == 'create':
             return EntryCreateSerializer
         return EntryDetailSerializer
-
-    def get_permissions(self):
-        if self.action in ('update', 'partial_update', 'destroy'):
-            permission_classes = [IsOwnerOrReadOnly]
-        else:
-            permission_classes = [IsAuthenticated]
-        return [permission() for permission in permission_classes]
 
 
 class RateUpdateView(generics.UpdateAPIView):

--- a/littleblog/entry/views.py
+++ b/littleblog/entry/views.py
@@ -3,41 +3,48 @@ from rest_framework import viewsets
 from .serializers import EntryCreateSerializer, UserProfileCreateSerializer, RateUpdateSerializer, EntryDetailSerializer
 from .models import Entry
 from rest_framework.permissions import IsAuthenticated, IsAdminUser, AllowAny
-from .permissons import IsOwnerOrReadOnly
+from .permissons import IsOwnerOrReadOnly, IsAuthenticatedOrWriteOnly
 from rest_framework.response import Response
 from django.contrib.auth import get_user_model
 from rest_framework import status
 
 
-class UserProfileCreateView(generics.CreateAPIView):
+class UserProfileCreateRetrieveView(generics.RetrieveAPIView,
+                                    generics.CreateAPIView):
 
     serializer_class = UserProfileCreateSerializer
+    queryset = get_user_model().objects.all()
+    permission_classes = (IsAuthenticatedOrWriteOnly,)
 
-    def create(self, request, *args, **kwargs):
-        data = request.data.dict()
-        data.pop('username')
-        data.pop('password')
-        data['user'] = kwargs.pop('user')
-        serializer = self.get_serializer(data=data)
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
-    def post(self, request, *args, **kwargs):
-        """
-        Сделаем так, чтобы User и UserProfile создавались одним махом. УРА! В этом коммите я сделал это! Для минимального
-        POST запроса нужны :  username и password (для создания модельки User), и nickname для модельки UserProfile.
-        """
-        usermodel = get_user_model()
-        user = usermodel.objects.create_user(username=request.data['username'], password=request.data['password'])
-        kwargs['user'] = user.pk
-
-        return self.create(request, *args, **kwargs)
+# class UserProfileCreateView(generics.CreateAPIView):
+#
+#     serializer_class = UserProfileCreateSerializer
+#
+#     def create(self, request, *args, **kwargs):
+#         data = request.data.dict()
+#         data.pop('username')
+#         data.pop('password')
+#         data['user'] = kwargs.pop('user')
+#         serializer = self.get_serializer(data=data)
+#         serializer.is_valid(raise_exception=True)
+#         self.perform_create(serializer)
+#         headers = self.get_success_headers(serializer.data)
+#         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+#
+#     def post(self, request, *args, **kwargs):
+#         """
+#         Сделаем так, чтобы User и UserProfile создавались одним махом. УРА! В этом коммите я сделал это! Для минимального
+#         POST запроса нужны :  username и password (для создания модельки User), и nickname для модельки UserProfile.
+#         """
+#         usermodel = get_user_model()
+#         user = usermodel.objects.create_user(username=request.data['username'], password=request.data['password'])
+#         kwargs['user'] = user.pk
+#
+#         return self.create(request, *args, **kwargs)
 
 
 class EntryViewSet(viewsets.ModelViewSet):
-
     queryset = Entry.objects.all()
     permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
 
@@ -60,7 +67,7 @@ class RateUpdateView(generics.UpdateAPIView):
         instance = self.get_object()
         instance.sum_of_marks += int(request.query_params['mark'])
         instance.amount_of_marks += 1
-        instance.current_rate = instance.sum_of_marks/instance.amount_of_marks
+        instance.current_rate = instance.sum_of_marks / instance.amount_of_marks
         instance.save()
 
         if getattr(instance, '_prefetched_objects_cache', None):
@@ -75,4 +82,3 @@ class RateUpdateView(generics.UpdateAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         obj = generics.get_object_or_404(queryset, pk=self.request.query_params['pk'])
         return obj
-


### PR DESCRIPTION
Refactor creation of User and User Profile.

Changes allow us to create 2 db entries of models with OneToOne relationship using 1 view, and to list/create Users with the same serializer without any nested ones.

fix #4 